### PR TITLE
Fix scoreboard preview layout and add default tournament logo

### DIFF
--- a/src/components/scoreboard_preview/scoreboard_types/ScoreboardType4.jsx
+++ b/src/components/scoreboard_preview/scoreboard_types/ScoreboardType4.jsx
@@ -3,6 +3,7 @@ import DisplayLogo from '../../common/DisplayLogo';
 import { FoulsDisplay } from '../../../utils/futsalUtils';
 
 const ScoreboardType4 = ({ currentData, logoShape, showMatchTime, tournamentLogo }) => {
+    const defaultTournamentLogo = 'https://upload.wikimedia.org/wikipedia/vi/thumb/9/91/FC_Barcelona_logo.svg/1200px-FC_Barcelona_logo.svg.png';
     const getTeamNameFontSize = (teamName, isMobile = false) => {
         const length = teamName ? teamName.length : 0;
         

--- a/src/components/scoreboard_preview/scoreboard_types/ScoreboardType4.jsx
+++ b/src/components/scoreboard_preview/scoreboard_types/ScoreboardType4.jsx
@@ -30,7 +30,7 @@ const ScoreboardType4 = ({ currentData, logoShape, showMatchTime, tournamentLogo
                     {/* Tournament/League Logo - Đặt riêng phía trên */}
                     <div className="absolute left-1/2 top-[-8px] sm:top-[-16px] -translate-x-1/2 w-[16px] h-[16px] sm:w-[52px] sm:h-[52px] z-50">
                         <DisplayLogo
-                            logos={[tournamentLogo || '/images/basic/logo-skin4.png']}
+                            logos={[tournamentLogo || defaultTournamentLogo]}
                             alt="Tournament"
                             type_play={logoShape}
                             className="w-full h-full"

--- a/src/components/sections/ScoreboardPreview.jsx
+++ b/src/components/sections/ScoreboardPreview.jsx
@@ -274,7 +274,8 @@ const ScoreboardPreview = ({ matchData, displaySettings }) => {
   );
 
   const renderScoreboardType4 = () => (
-    <div className="flex items-center justify-center gap-0">
+    <div className="flex items-center justify-center gap-0 scale-50 origin-center">
+      {/* Team A Logo */}
       <div className="w-6 h-6 rounded-full flex items-center justify-center overflow-hidden">
         <img
           src={currentData.teamALogo}
@@ -292,7 +293,7 @@ const ScoreboardPreview = ({ matchData, displaySettings }) => {
 
       <div className="flex items-center gap-0 -space-x-2">
         <div
-          className="text-white text-xs font-semibold flex items-center justify-center w-16 h-5"
+          className="text-white text-xs font-semibold flex items-center justify-center w-24 h-6"
           style={{
             background: 'linear-gradient(90deg, rgb(222, 57, 51), rgb(238, 134, 58))',
             clipPath: 'polygon(15% 0%, 85% 0%, 100% 100%, 0% 100%)'
@@ -301,7 +302,7 @@ const ScoreboardPreview = ({ matchData, displaySettings }) => {
           <span className="truncate text-center">{currentData.teamAName}</span>
         </div>
         <div
-          className="w-6 h-5 z-10"
+          className="w-8 h-6 z-10"
           style={{
             backgroundColor: currentData.teamAKitColor,
             clipPath: 'polygon(0% 0%, 55% 0%, 100% 100%, 45% 100%)'
@@ -316,15 +317,15 @@ const ScoreboardPreview = ({ matchData, displaySettings }) => {
             backgroundColor: '#213f80',
             clipPath: 'polygon(15% 0%, 85% 0%, 100% 100%, 0% 100%)',
             minHeight: '32px',
-            width: '120px'
+            width: '80px'
           }}
         >
           <div className="text-white font-bold text-sm min-w-[1rem] text-center">
             {currentData.teamAScore}
           </div>
-          <div className="mx-1 w-5 h-5 rounded-full flex items-center justify-center text-xs overflow-hidden">
+          <div className="mx-1 w-4 h-4 rounded-full flex items-center justify-center text-xs overflow-hidden">
             <img
-              src="/api/placeholder/20/20"
+              src="https://upload.wikimedia.org/wikipedia/vi/thumb/9/91/FC_Barcelona_logo.svg/1200px-FC_Barcelona_logo.svg.png"
               alt="League Logo"
               className="w-full h-full object-cover"
               onError={(e) => {
@@ -347,14 +348,14 @@ const ScoreboardPreview = ({ matchData, displaySettings }) => {
 
       <div className="flex items-center gap-0 -space-x-2">
         <div
-          className="w-6 h-5 z-10"
+          className="w-8 h-6 z-10"
           style={{
             backgroundColor: currentData.teamBKitColor,
             clipPath: 'polygon(45% 0%, 100% 0%, 55% 100%, 0% 100%)'
           }}
         />
         <div
-          className="text-white text-xs font-semibold flex items-center justify-center w-16 h-5"
+          className="text-white text-xs font-semibold flex items-center justify-center w-24 h-6"
           style={{
             background: 'linear-gradient(90deg, rgb(222, 57, 51), rgb(238, 134, 58))',
             clipPath: 'polygon(15% 0%, 85% 0%, 100% 100%, 0% 100%)'
@@ -364,6 +365,7 @@ const ScoreboardPreview = ({ matchData, displaySettings }) => {
         </div>
       </div>
 
+      {/* Team B Logo */}
       <div className="w-6 h-6 rounded-full flex items-center justify-center overflow-hidden">
         <img
           src={currentData.teamBLogo}

--- a/src/pages/Poster-haoquang.jsx
+++ b/src/pages/Poster-haoquang.jsx
@@ -183,7 +183,7 @@ export default function HaoQuangMatchIntro() {
           <div className="flex-1 flex flex-col justify-center min-h-0">
 
             {/* Title section */}
-            <div className="text-center mb-0 sm:mb-1 md:mb-2">
+            <div className="text-center mb-0 sm:mb-0 md:mb-1">
               <h1
                 className="title text-white px-1 sm:px-2"
               >


### PR DESCRIPTION
## Purpose
The user requested several UI improvements to enhance the scoreboard preview display and poster layout:
1. Reduce padding/margin for the title section on both desktop and mobile
2. Adjust the scoreboard preview component to match updated scoreboard types with proper width alignment
3. Add a default tournament logo URL for ScoreboardType4 component
4. Ensure the preview component displays correctly as it's only for preview purposes

## Code changes
- **ScoreboardType4.jsx**: Added default tournament logo URL (FC Barcelona logo from Wikimedia) as fallback when no tournament logo is provided
- **ScoreboardPreview.jsx**: 
  - Applied 50% scale transformation to scoreboard type 4 preview for better fit
  - Adjusted element dimensions (width from 16px to 24px, height from 5px to 6px)
  - Updated score container width from 120px to 80px for better proportions
  - Replaced placeholder tournament logo with the default FC Barcelona logo
  - Added descriptive comments for team logo sections
- **Poster-haoquang.jsx**: Reduced bottom margin for title section on small and medium screens (sm:mb-1 to sm:mb-0, md:mb-2 to md:mb-1)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 224`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e4276d01feae478596652fa23d2947a6/pixel-works)

👀 [Preview Link](https://e4276d01feae478596652fa23d2947a6-pixel-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e4276d01feae478596652fa23d2947a6</projectId>-->
<!--<branchName>pixel-works</branchName>-->