### PR TITLE
Add HEIC to JPEG/PNG conversion for iPhone uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.11.0",
         "dom-to-image": "^2.6.0",
+        "heic2any": "^0.0.4",
         "html-to-image": "^1.11.13",
         "html2canvas": "^1.4.1",
         "lucide-react": "^0.533.0",
@@ -8527,6 +8528,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/hoopy": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.11.0",
     "dom-to-image": "^2.6.0",
+    "heic2any": "^0.0.4",
     "html-to-image": "^1.11.13",
     "html2canvas": "^1.4.1",
     "lucide-react": "^0.533.0",

--- a/src/components/poster/PosterLogoManager.jsx
+++ b/src/components/poster/PosterLogoManager.jsx
@@ -6,8 +6,9 @@ import RoomSessionAPI from "../../API/apiRoomSession";
 import { getFullLogoUrl, getFullPosterUrl } from "../../utils/logoUtils";
 import socketService from "../../services/socketService";
 import {availablePosters, logoTypes} from '../../utils/poster';
+import { isHeicFile, convertHeicToJpegOrPng } from "../../utils/imageUtils";
 const PosterLogoManager = React.memo(({ onPosterUpdate, onLogoUpdate, initialData, accessCode }) => {
-  // console.log('🗨️ [PosterLogoManager] Component initialized with props:', {
+  // console.log('��️ [PosterLogoManager] Component initialized with props:', {
   //   onPosterUpdate: !!onPosterUpdate,
   //   onLogoUpdate: !!onLogoUpdate,
   //   initialData,
@@ -196,7 +197,7 @@ const PosterLogoManager = React.memo(({ onPosterUpdate, onLogoUpdate, initialDat
                   loadedLogos.push(logoItem);
                 });
               } else {
-                // console.log('📋 [PosterLogoManager] No organizing found or organizing is not an array');
+                // console.log('��� [PosterLogoManager] No organizing found or organizing is not an array');
               }
 
               // Process media (nếu có trong response)
@@ -304,8 +305,18 @@ const PosterLogoManager = React.memo(({ onPosterUpdate, onLogoUpdate, initialDat
   }, [updateSelectedLogosCount]);
 
   const handlePosterUpload = async (event) => {
-    const file = event.target.files[0];
+    let file = event.target.files[0];
     if (!file) return;
+
+    // Convert HEIC/HEIF from iPhone to JPEG before validations
+    if (isHeicFile(file)) {
+      try {
+        file = await convertHeicToJpegOrPng(file, 'image/jpeg', 0.92);
+      } catch (err) {
+        alert('Không thể chuyển HEIC sang JPEG/PNG. Vui lòng chọn ảnh JPEG/PNG.');
+        return;
+      }
+    }
 
     // Kiểm tra giới hạn tối đa 1 poster
     const uploadedPostersCount = [...savedPosters, ...customPosters].length;
@@ -381,8 +392,18 @@ const PosterLogoManager = React.memo(({ onPosterUpdate, onLogoUpdate, initialDat
   };
 
   const handleFileUpload = async (event, item) => {
-    const file = event.target.files[0];
+    let file = event.target.files[0];
     if (!file) return;
+
+    // Convert HEIC/HEIF from iPhone to JPEG before validations
+    if (isHeicFile(file)) {
+      try {
+        file = await convertHeicToJpegOrPng(file, 'image/jpeg', 0.92);
+      } catch (err) {
+        alert('Không thể chuyển HEIC sang JPEG/PNG. Vui lòng chọn ảnh JPEG/PNG.');
+        return;
+      }
+    }
 
     if (file.size > 5 * 1024 * 1024) {
       alert("Kích thước file tối đa là 5MB");
@@ -762,7 +783,7 @@ const PosterLogoManager = React.memo(({ onPosterUpdate, onLogoUpdate, initialDat
                 }`}
             >
               {item.uploadStatus === 'preview' ? '⏳ Đang tải...' :
-                item.uploadStatus === 'error' ? '❌ Thử lại' :
+                item.uploadStatus === 'error' ? '��� Thử lại' :
                   '📁 Chọn file'}
             </label>
           </div>

--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -1,0 +1,21 @@
+export function isHeicFile(file) {
+  if (!file) return false;
+  const type = (file.type || '').toLowerCase();
+  const name = (file.name || '').toLowerCase();
+  return type === 'image/heic' || type === 'image/heif' || /\.(heic|heif)$/.test(name);
+}
+
+export async function convertHeicToJpegOrPng(file, toType = 'image/jpeg', quality = 0.92) {
+  if (!file) throw new Error('No file provided');
+  try {
+    const mod = await import('heic2any');
+    const heic2any = mod.default || mod;
+    const result = await heic2any({ blob: file, toType, quality });
+    const blob = Array.isArray(result) ? result[0] : result;
+    const ext = toType === 'image/png' ? '.png' : '.jpg';
+    const newName = (file.name || 'image').replace(/\.(heic|heif)$/i, ext);
+    return new File([blob], newName, { type: toType });
+  } catch (err) {
+    throw new Error('HEIC conversion failed');
+  }
+}


### PR DESCRIPTION
## Purpose

The user identified an issue where uploading logo images from iPhone devices was failing while Android uploads worked fine. This was due to iPhone's default HEIC image format not being supported. The user requested adding HEIC to JPEG/PNG conversion functionality to resolve this compatibility issue.

## Code changes

- **Added heic2any dependency** (v0.0.4) to package.json for HEIC format conversion
- **Created imageUtils.js** with two utility functions:
  - `isHeicFile()`: Detects HEIC/HEIF files by MIME type and file extension
  - `convertHeicToJpegOrPng()`: Converts HEIC files to JPEG/PNG format
- **Updated PosterLogoManager.jsx** to handle HEIC conversion:
  - Added HEIC detection and conversion in both `handlePosterUpload()` and `handleFileUpload()` functions
  - Converts HEIC files to JPEG (92% quality) before validation and upload
  - Shows user-friendly error message if conversion fails
  - Maintains existing file validation and upload logic

This fix ensures iPhone users can successfully upload logo images by automatically converting HEIC format to web-compatible JPEG format.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 243`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cade0b2ea90645479fbe1d881b7f4eaa/orbit-world)

👀 [Preview Link](https://cade0b2ea90645479fbe1d881b7f4eaa-orbit-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cade0b2ea90645479fbe1d881b7f4eaa</projectId>-->
<!--<branchName>orbit-world</branchName>-->